### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ upstream이란, 내가 fork를 떴던 원래 저장소를 의미합니다.
 
 내 저장소 페이지에서 저장소 이름 아래를 보면 **forked from :** 으로 표시됩니다.
 
-PR을 제출하려면 upstream 저장소로 이동하여 **Pull request** 탭을 누르고, **New pull request** 버튼을 누르세요.
+PR을 제출하려면 **Pull request** 탭을 누르고, **New pull request** 버튼을 누르세요.
 
 GitHub가 자동으로 감지하지 못하는 경우 *compare across forks*를 클릭해주세요. 그 다음 PR을 생성하세요.
 


### PR DESCRIPTION
개인 repo만든 상태에서 upstream(GDG-Seoul)로 이동하여 PR 생성시  PandelisZ/workshop-guestbook 쪽이 base로 PR이 생성됩니다.
환경차이가 있을 수 있겠지만 개인 repo에서 PR 생성시 GDG 쪽으로 PR이 생성되는걸 확인했습니다.
PR에 익숙하지 않은분들을 고려하여 개인 저장소에서 PR을 생성하는쪽이 좋을거같습니다.